### PR TITLE
Changed `const` to `let` in es6 Array.map example

### DIFF
--- a/manuscript/appendices/01_language_features.md
+++ b/manuscript/appendices/01_language_features.md
@@ -275,8 +275,8 @@ In ES6 we could write it as follows:
 
 ```javascript
 function map(cb, values) {
-  const ret = [];
-  const i, len;
+  let ret = [];
+  let i, len;
 
   for(i = 0, len = values.length; i < len; i++) {
     ret.push(cb(values[i]));


### PR DESCRIPTION
Both the counter and the result array were constants, which caused a syntax error as they tried to mutate.